### PR TITLE
Fix the wrong byte order flag which cause failure on iOS 15+

### DIFF
--- a/SDWebImageBPGCoder/Classes/SDImageBPGCoder.m
+++ b/SDWebImageBPGCoder/Classes/SDImageBPGCoder.m
@@ -432,7 +432,7 @@ static void FillRGBABufferWithBPGImage(vImage_Buffer *red, vImage_Buffer *green,
     size_t bitsPerPixel = hasAlpha ? 32 : 24;
     size_t bytesPerRow = width * bitsPerPixel / 8;
     size_t rgbaSize = height * bytesPerRow;
-    CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Big;
+    CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault;
     bitmapInfo |= hasAlpha ? kCGImageAlphaLast : kCGImageAlphaNone;
     
     uint8_t *rgba = malloc(rgbaSize);


### PR DESCRIPTION
This fix the CGImage's `invalid image byte order info for` wrong behavior 
close #9 